### PR TITLE
Django 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 .idea
+.vscode/
+
+

--- a/announcements/models.py
+++ b/announcements/models.py
@@ -79,7 +79,7 @@ def current_announcements_for_request(request, **kwargs):
     the ``excluded_announcements`` session variable.
     """
     defaults = {}
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         defaults["for_members"] = True
     defaults["exclude"] = request.session.get("excluded_announcements", set())
     defaults.update(kwargs)

--- a/announcements/models.py
+++ b/announcements/models.py
@@ -2,7 +2,6 @@ from datetime import datetime
 
 from django.db import models
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
@@ -43,7 +42,7 @@ class Announcement(models.Model):
     """
     title = models.CharField(_("title"), max_length=50)
     content = models.TextField(_("content"))
-    creator = models.ForeignKey(User, verbose_name=_("creator"), on_delete=models.CASCADE)
+    creator = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_("creator"), on_delete=models.CASCADE)
     creation_date = models.DateTimeField(_("creation_date"), default=datetime.now)
     site_wide = models.BooleanField(_("site wide"), default=False)
     members_only = models.BooleanField(_("members only"), default=False)


### PR DESCRIPTION
fixes announcements models to use auth.usermodels instead of hardcoded User.